### PR TITLE
Pebble templating.

### DIFF
--- a/spark-template-pebble/README.md
+++ b/spark-template-pebble/README.md
@@ -1,0 +1,31 @@
+spark-template-pebble
+==============================================
+
+How to use the Pebble template route for Spark example:
+
+```java
+import spark.ModelAndView;
+import spark.template.pebble.PebbleTemplateEngine;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static spark.Spark.get;
+
+/**
+ * @author Nikki
+ */
+public class PebbleExample {
+
+	public static void main(String[] args) {
+		get("/hello", (request, response) -> {
+			Map<String, Object> attributes = new HashMap<>();
+			attributes.put("message", "Hello World!");
+
+			// The hello.pebble file is located in directory:
+			// src/test/resources/spark/template/pebble
+			return new ModelAndView(attributes, "hello.pebble");
+		}, new PebbleTemplateEngine());
+	}
+}
+```

--- a/spark-template-pebble/pom.xml
+++ b/spark-template-pebble/pom.xml
@@ -1,0 +1,73 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
+    <groupId>com.sparkjava</groupId>
+    <artifactId>spark-template-pebble</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0.0</version>
+
+    <name>spark-template-mustache</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.mitchellbosecke</groupId>
+            <artifactId>pebble</artifactId>
+            <version>1.4.4</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <optimize>true</optimize>
+                    <debug>true</debug>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.14</version>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.8</version>
+                <configuration>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/spark-template-pebble/src/main/java/spark/template/pebble/PebbleTemplateEngine.java
+++ b/spark-template-pebble/src/main/java/spark/template/pebble/PebbleTemplateEngine.java
@@ -1,0 +1,79 @@
+package spark.template.pebble;
+
+import com.mitchellbosecke.pebble.PebbleEngine;
+import com.mitchellbosecke.pebble.error.PebbleException;
+import com.mitchellbosecke.pebble.loader.ClasspathLoader;
+import com.mitchellbosecke.pebble.loader.Loader;
+import com.mitchellbosecke.pebble.template.PebbleTemplate;
+import spark.ModelAndView;
+import spark.TemplateEngine;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+
+/**
+ * Template Engine based on Pebble.
+ *
+ * @author Nikki
+ */
+public class PebbleTemplateEngine extends TemplateEngine {
+
+	/**
+	 * The Pebble Engine instance.
+	 */
+	private final PebbleEngine engine;
+
+	/**
+	 * Construct a new template engine using pebble with a default engine.
+	 */
+	public PebbleTemplateEngine() {
+		Loader loader = new ClasspathLoader();
+		loader.setPrefix("");
+		this.engine = new PebbleEngine(loader);
+	}
+
+	/**
+	 * Construct a new template engine using pebble with an engine using a special loader.
+	 */
+	public PebbleTemplateEngine(Loader loader) {
+		this.engine = new PebbleEngine(loader);
+	}
+
+	/**
+	 * Construct a new template engine using pebble with a specified engine.
+	 *
+	 * @param engine The pebble template engine.
+	 */
+	public PebbleTemplateEngine(PebbleEngine engine) {
+		this.engine = engine;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	@SuppressWarnings("unchecked")
+	public String render(ModelAndView modelAndView) {
+		Object model = modelAndView.getModel();
+
+		if (model == null || model instanceof Map) {
+			try {
+				StringWriter writer = new StringWriter();
+
+				PebbleTemplate template = engine.getTemplate(modelAndView.getViewName());
+				if (model == null) {
+					template.evaluate(writer);
+				} else {
+					template.evaluate(writer, (Map<String, Object>) modelAndView.getModel());
+				}
+
+				return writer.toString();
+			} catch (PebbleException | IOException e) {
+				throw new IllegalArgumentException(e);
+			}
+		} else {
+			throw new IllegalArgumentException("Invalid model, model must be instance of Map.");
+		}
+	}
+}

--- a/spark-template-pebble/src/test/java/spark/template/pebble/PebbleExample.java
+++ b/spark-template-pebble/src/test/java/spark/template/pebble/PebbleExample.java
@@ -1,0 +1,25 @@
+package spark.template.pebble;
+
+import spark.ModelAndView;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static spark.Spark.get;
+
+/**
+ * @author Nikki
+ */
+public class PebbleExample {
+
+	public static void main(String[] args) {
+		get("/hello", (request, response) -> {
+			Map<String, Object> attributes = new HashMap<>();
+			attributes.put("message", "Hello World!");
+
+			// The hello.pebble file is located in directory:
+			// src/test/resources/spark/template/pebble
+			return new ModelAndView(attributes, "templates/hello.pebble");
+		}, new PebbleTemplateEngine());
+	}
+}

--- a/spark-template-pebble/src/test/resources/templates/hello.pebble
+++ b/spark-template-pebble/src/test/resources/templates/hello.pebble
@@ -1,0 +1,2 @@
+<h1>{{ message }}</h1>
+<h1>The above text is set using a PebbleTemplateEngine</h1>


### PR DESCRIPTION
Updated and not messing up any formatting. Uses Pebble 1.4.4, and references Spark 2.1.