### PR TITLE
Upgrade mustache.java to the latest release

### DIFF
--- a/spark-template-mustache/pom.xml
+++ b/spark-template-mustache/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
-            <version>0.8.15</version>
+            <version>0.9.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
The current release of mustache.java is Java 8 only and supports things like Java's Function interface and Optional.