### PR TITLE
Upgraded watertemplate engine to 1.2.0

### DIFF
--- a/spark-template-water/pom.xml
+++ b/spark-template-water/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-water</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <name>spark-template-water</name>
     <url>http://www.sparkjava.com</url>
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.watertemplate</groupId>
             <artifactId>watertemplate-engine</artifactId>
-            <version>1.1.0</version>
+            <version>1.2.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Water engine 1.1.0 has some bugs, notably with the handling of : in URLs. 1.2.0 fixes that.