### PR TITLE
Make handlebars object protected so subclass can register helpers.

### DIFF
--- a/spark-template-handlebars/src/main/java/spark/template/handlebars/HandlebarsTemplateEngine.java
+++ b/spark-template-handlebars/src/main/java/spark/template/handlebars/HandlebarsTemplateEngine.java
@@ -40,7 +40,7 @@ import com.google.common.cache.CacheBuilder;
  */
 public class HandlebarsTemplateEngine extends TemplateEngine {
 
-    private Handlebars handlebars;
+    protected Handlebars handlebars;
 
     /**
      * Constructs a handlebars template engine

--- a/spark-template-handlebars/src/test/java/spark/template/handlebars/HandlebarsHelperExample.java
+++ b/spark-template-handlebars/src/test/java/spark/template/handlebars/HandlebarsHelperExample.java
@@ -1,0 +1,32 @@
+package spark.template.handlebars;
+
+import spark.ModelAndView;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static spark.Spark.get;
+
+public class HandlebarsHelperExample extends HandlebarsTemplateEngine {
+
+    public HandlebarsHelperExample() {
+        super();
+        handlebars.registerHelpers(this);
+    }
+
+    // Example of a helper, write {{now}} in template file.
+    public String now() {
+        return new Date().toString();
+    }
+
+    public static void main(String[] args) {
+        Map map = new HashMap();
+        map.put("name", "Chris");
+
+        // hello.hbs file is in resources/templates directory
+        get("/hello", (rq, rs) -> new ModelAndView(map, "hello.hbs"),
+                new HandlebarsHelperExample());
+
+    }
+}

--- a/spark-template-handlebars/src/test/resources/templates/hello.hbs
+++ b/spark-template-handlebars/src/test/resources/templates/hello.hbs
@@ -1,1 +1,2 @@
 Hello, {{name}}!
+{{now}}


### PR DESCRIPTION
I wanted to be able to use handlebars.registerHelpers, but I had to copy/paste the entire HandlebarsTemplateEngine into my project because the handlebars field is private.

Can we make it protected? Then I can just override the constructor and register the helpers there.

Includes a sample program in HandlebarsHelperExample.
