### PR TITLE
Updates spark-template-pebble for 2.x.x for #32

### DIFF
--- a/spark-template-pebble/pom.xml
+++ b/spark-template-pebble/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>com.mitchellbosecke</groupId>
             <artifactId>pebble</artifactId>
-            <version>1.6.0</version>
+            <version>2.2.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/spark-template-pebble/src/main/java/spark/template/pebble/PebbleTemplateEngine.java
+++ b/spark-template-pebble/src/main/java/spark/template/pebble/PebbleTemplateEngine.java
@@ -44,16 +44,14 @@ public class PebbleTemplateEngine extends TemplateEngine {
 	 * Construct a new template engine using pebble with a default engine.
 	 */
 	public PebbleTemplateEngine() {
-		Loader loader = new ClasspathLoader();
-		loader.setPrefix("");
-		this.engine = new PebbleEngine(loader);
+		this.engine = new PebbleEngine.Builder().build();
 	}
 
 	/**
 	 * Construct a new template engine using pebble with an engine using a special loader.
 	 */
 	public PebbleTemplateEngine(Loader loader) {
-		this.engine = new PebbleEngine(loader);
+		this.engine = new PebbleEngine.Builder().loader(loader).build();
 	}
 
 	/**

--- a/spark-template-pebble/src/test/java/spark/template/pebble/PebbleExample.java
+++ b/spark-template-pebble/src/test/java/spark/template/pebble/PebbleExample.java
@@ -16,7 +16,7 @@ public class PebbleExample {
 		get("/hello", (request, response) -> {
 			Map<String, Object> attributes = new HashMap<>();
 			attributes.put("message", "Hello World!");
-
+			
 			// The hello.pebble file is located in directory:
 			// src/test/resources/spark/template/pebble
 			return new ModelAndView(attributes, "templates/hello.pebble");


### PR DESCRIPTION
Fixes #32.

Updates to PebbleEngine.Builder, and adds appropriate pathing to example template (hello.pebble).

The default constructor for PebbleTemplateEngine now does not specify a loader, so we default to PebbleEngine's DelegatingLoader as consequence.