### PR TITLE
Update spark-template-jade Jade4J dependency to 1.2.3

### DIFF
--- a/spark-template-jade/pom.xml
+++ b/spark-template-jade/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>de.neuland-bfi</groupId>
             <artifactId>jade4j</artifactId>
-            <version>1.0.7</version>
+            <version>1.2.3</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Jade4J received a lot of fixes between version 1.07 (currently used by spark-template-jade) and current version 1.2.3.