### PR TITLE
Jtwig template engine for Spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>spark-template-jade</module>
         <module>spark-template-jetbrick</module>
         <module>spark-template-jinjava</module>
+        <module>spark-template-jtwig</module>
         <module>spark-template-mustache</module>
         <module>spark-template-pebble</module>
         <module>spark-template-thymeleaf</module>

--- a/spark-template-jtwig/LICENSE
+++ b/spark-template-jtwig/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/spark-template-jtwig/README.md
+++ b/spark-template-jtwig/README.md
@@ -1,0 +1,23 @@
+spark-template-jtwig
+====================
+
+Spark templating system using Jtwig.
+
+```java
+import static spark.Spark.get;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import spark.ModelAndView;
+
+public class JtwigTemplateExample {
+    public static void main(String[] args) {
+        Map map = new HashMap();
+        map.put("name", "Rafa");
+
+        // hello.twig file is in resources/templates directory
+        get("/hello", (rq, rs) -> new ModelAndView(map, "hello.twig"), new JtwigTemplateEngine());
+    }
+}
+```

--- a/spark-template-jtwig/pom.xml
+++ b/spark-template-jtwig/pom.xml
@@ -1,0 +1,81 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
+
+    <groupId>com.sparkjava</groupId>
+    <artifactId>spark-template-jtwig</artifactId>
+    <packaging>jar</packaging>
+    <version>2.4-SNAPSHOT</version>
+
+    <name>spark-template-jtwig</name>
+    <url>http://www.sparkjava.com</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jtwig</groupId>
+            <artifactId>jtwig-core</artifactId>
+            <version>5.65</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <optimize>true</optimize>
+                    <debug>true</debug>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.14</version>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.8</version>
+                <configuration>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/spark-template-jtwig/src/main/java/spark/template/jtwig/JtwigTemplateEngine.java
+++ b/spark-template-jtwig/src/main/java/spark/template/jtwig/JtwigTemplateEngine.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2014
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package spark.template.jtwig;
+
+import java.util.Map;
+
+import org.jtwig.JtwigModel;
+import org.jtwig.JtwigTemplate;
+
+import spark.ModelAndView;
+import spark.TemplateEngine;
+
+/**
+ * Defaults to the 'templates' directory under the resource path.
+ *
+ * @author Sam Pullara https://github.com/spullara
+ */
+public class JtwigTemplateEngine extends TemplateEngine {
+
+	/**
+	 * Templates directory in resources
+	 */
+	private String templatesDirectory;
+
+	/**
+	 * Setup default templates directory
+	 */
+	public JtwigTemplateEngine() {
+		this.templatesDirectory = "templates";
+	}
+
+	/**
+	 * Setup custom templates directory
+	 * 
+	 * @param customTemplatesDirectory
+	 *            The custom templates directory
+	 */
+	public JtwigTemplateEngine(String customTemplatesDirectory) {
+		this.templatesDirectory = customTemplatesDirectory;
+	}
+
+	@Override
+	public String render(ModelAndView modelAndView) {
+		String viewName = templatesDirectory + "/" + modelAndView.getViewName();
+		JtwigTemplate template = JtwigTemplate.classpathTemplate(viewName);
+		JtwigModel model = JtwigModel.newModel((Map) modelAndView.getModel());
+		return template.render(model);
+	}
+}

--- a/spark-template-jtwig/src/test/java/spark/template/jtwig/JtwigTemplateExample.java
+++ b/spark-template-jtwig/src/test/java/spark/template/jtwig/JtwigTemplateExample.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package spark.template.jtwig;
+
+import static spark.Spark.get;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import spark.ModelAndView;
+
+/**
+ * Jtwig template engine example
+ *
+ * @author Rafael Andrade de Oliveira https://github.com/eurafa
+ */
+public class JtwigTemplateExample {
+	public static void main(String[] args) {
+		Map map = new HashMap();
+		map.put("name", "Rafa");
+
+		// hello.twig file is in resources/templates directory
+		get("/hello", (rq, rs) -> new ModelAndView(map, "hello.twig"),
+				new JtwigTemplateEngine());
+	}
+}

--- a/spark-template-jtwig/src/test/java/spark/template/jtwig/JtwigTemplateExample.java
+++ b/spark-template-jtwig/src/test/java/spark/template/jtwig/JtwigTemplateExample.java
@@ -18,6 +18,7 @@ package spark.template.jtwig;
 
 import static spark.Spark.get;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,6 +33,7 @@ public class JtwigTemplateExample {
 	public static void main(String[] args) {
 		Map map = new HashMap();
 		map.put("name", "Rafa");
+		map.put("today", new Date());
 
 		// hello.twig file is in resources/templates directory
 		get("/hello", (rq, rs) -> new ModelAndView(map, "hello.twig"),

--- a/spark-template-jtwig/src/test/resources/templates/greeting.twig
+++ b/spark-template-jtwig/src/test/resources/templates/greeting.twig
@@ -1,0 +1,21 @@
+{% set isRafa = (name == "Rafa") %}
+
+{% if (isRafa) %}
+    You are the best!
+{% else %}
+    Nice to meet you
+    {% for i in [1..3] %}.{% endfor %}
+{% endif %}
+
+{% set weekNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"] %}
+{% set dayOfWeek = today.getDay() %}
+
+<div>
+Today is {{ weekNames[dayOfWeek] }}.
+</div>
+
+{% if (dayOfWeek == 5) %}
+    Take it easy.
+{% elseif (dayOfWeek in [0,6]) %}
+	Take some rest.
+{% endif %}

--- a/spark-template-jtwig/src/test/resources/templates/hello.twig
+++ b/spark-template-jtwig/src/test/resources/templates/hello.twig
@@ -1,0 +1,1 @@
+Hello, {{name}}!

--- a/spark-template-jtwig/src/test/resources/templates/hello.twig
+++ b/spark-template-jtwig/src/test/resources/templates/hello.twig
@@ -1,1 +1,3 @@
 Hello, {{name}}!
+
+{% include "greeting.twig" %}


### PR DESCRIPTION
Hi,

I wrote this morning a new template engine to use **Jtwig** (based on Twig) template in my views.
Jtwig is a modern, lovely and powerful template engine.
Please check [Jtwig](http://jtwig.org/).

So, I would like to share to Spark community.
What do you think about it?

Please, let me know how to help updating Spark documentation.

Best regards,
Rafa.