### PR TITLE
Update Water template engine dependency versions

### DIFF
--- a/spark-template-water/pom.xml
+++ b/spark-template-water/pom.xml
@@ -12,7 +12,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-water</artifactId>
     <packaging>jar</packaging>
-    <version>2.3</version>
+    <version>2.5.3</version>
 
     <name>spark-template-water</name>
     <url>http://www.sparkjava.com</url>
@@ -21,12 +21,14 @@
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>2.3</version>
+            <version>2.5.3</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.watertemplate</groupId>
             <artifactId>watertemplate-engine</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.2</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I also made the two dependencies scope provided, so users can decide which version to use. As long as the API keeps the same, there's no problem in upgrading.