### PR TITLE
added rocker templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <module>spark-template-jtwig</module>
         <module>spark-template-mustache</module>
         <module>spark-template-pebble</module>
+        <module>spark-template-rocker</module>
         <module>spark-template-thymeleaf</module>
         <module>spark-template-velocity</module>
         <module>spark-template-water</module>

--- a/spark-template-rocker/README.md
+++ b/spark-template-rocker/README.md
@@ -1,0 +1,48 @@
+spark-template-rocker 
+==============================================
+
+2 ways to use [Rocker](https://github.com/fizzed/rocker) templates in Spark:
+
+1) Using the template class with the ResponseTransformer:
+
+```java
+import spark.template.rocker.RockerTransformer;
+import static spark.Spark.get;
+
+public class RockerTransformerExample {
+
+    public static void main(String args[]) {
+
+        get("/hello", (request, response) -> {
+	        return views.hello.template("Hello Rocker!");
+        }, new RockerTransformer());
+
+    }
+
+}
+```
+
+2) Using the template name with the TemplateEngine:
+
+```java
+import java.util.HashMap;
+import java.util.Map;
+
+import spark.ModelAndView;
+import spark.template.rocker.RockerEngine;
+import static spark.Spark.get;
+
+public class RockerEngineExample {
+
+    public static void main(String args[]) {
+
+        get("/hello", (request, response) -> {
+            Map<String, Object> model = new HashMap<>();
+            model.put("message", "Hello Rocker!");
+            return new ModelAndView(model, "views/hello.rocker.html");
+        }, new RockerEngine());
+
+    }
+
+}
+```

--- a/spark-template-rocker/pom.xml
+++ b/spark-template-rocker/pom.xml
@@ -1,0 +1,159 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>7</version>
+    </parent>
+    <groupId>com.sparkjava</groupId>
+    <artifactId>spark-template-rocker</artifactId>
+    <packaging>jar</packaging>
+    <version>2.6-SNAPSHOT</version>
+
+    <name>spark-template-rocker</name>
+    <description>Rocker Template Engine implementation for Spark</description>
+    <url>http://www.sparkjava.com</url>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git@github.com:perwendel/spark-template-rocker.git</connection>
+        <developerConnection>scm:git:git@github.com:perwendel/spark-template-rocker.git</developerConnection>
+        <url>scm:git:git@github.com:perwendel/spark-template-rocker.git</url>
+    </scm>
+    <developers>
+    </developers>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- LOGGING DEPENDENCIES -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.13</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.13</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>2.5.1</version>
+        </dependency>
+
+	<dependency>
+            <groupId>com.fizzed</groupId>
+            <artifactId>rocker-runtime</artifactId>
+            <version>0.14.0</version>
+        </dependency>
+
+        <!-- for hot-reloading support -->
+        <dependency>
+            <groupId>com.fizzed</groupId>
+            <artifactId>rocker-compiler</artifactId>
+            <version>0.14.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- JUNIT DEPENDENCY FOR TESTING -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>false</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <filtering>false</filtering>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**</include>
+                </includes>
+                <excludes>
+                    <exclude>**/*.java</exclude>
+                </excludes>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>com.fizzed</groupId>
+                <artifactId>rocker-maven-plugin</artifactId>
+                <version>0.14.0</version>
+                <executions>
+                    <execution>
+                        <id>generate-rocker-templates</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <phase>generate-test-sources</phase>
+                        <configuration>
+                            <javaVersion>1.8</javaVersion>
+                            <templateDirectory>${basedir}/src/test/java</templateDirectory>
+                            <classDirectory>${basedir}/target/test-classes</classDirectory>
+                            <outputDirectory>${basedir}/target/generated-test-sources/rocker</outputDirectory>
+                            <addAsTestSources>true</addAsTestSources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <optimize>true</optimize>
+                    <debug>true</debug>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.14</version>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.8</version>
+                <configuration>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spark-template-rocker/src/main/java/spark/template/rocker/RockerEngine.java
+++ b/spark-template-rocker/src/main/java/spark/template/rocker/RockerEngine.java
@@ -1,0 +1,24 @@
+package spark.template.rocker;
+
+import java.util.Map;
+
+import com.fizzed.rocker.Rocker;
+import spark.ModelAndView;
+import spark.TemplateEngine;
+
+/**
+ */
+public class RockerEngine extends TemplateEngine {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String render(ModelAndView modelAndView) {
+	return Rocker.template(modelAndView.getViewName())
+	    .bind((Map<String,Object>)modelAndView.getModel())
+	    .render()
+	    .toString();
+    }
+
+}

--- a/spark-template-rocker/src/main/java/spark/template/rocker/RockerTransformer.java
+++ b/spark-template-rocker/src/main/java/spark/template/rocker/RockerTransformer.java
@@ -1,0 +1,18 @@
+package spark.template.rocker;
+
+import com.fizzed.rocker.runtime.DefaultRockerModel;
+import spark.ResponseTransformer;
+
+/**
+ */
+public class RockerTransformer implements ResponseTransformer {
+
+    /**
+     * {@inheritDoc}
+     */    
+    @Override
+    public String render(final Object o) throws Exception {
+        return ((DefaultRockerModel) o).render().toString();
+    }
+
+}

--- a/spark-template-rocker/src/test/java/spark/template/rocker/RockerEngineTest.java
+++ b/spark-template-rocker/src/test/java/spark/template/rocker/RockerEngineTest.java
@@ -1,0 +1,22 @@
+package spark.template.rocker;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import spark.ModelAndView;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class RockerEngineTest {
+
+    @Test
+    public void testRender() throws Exception {
+        String templateVariable = "Hello Rocker!";
+        Map<String, Object> model = new HashMap<>();
+        model.put("message", templateVariable);
+        String expected = String.format("<h1>%s</h1>\n", templateVariable);
+        String actual = new RockerEngine().render(new ModelAndView(model, "views/hello.rocker.html"));
+	assertEquals(expected, actual);
+    }
+
+}

--- a/spark-template-rocker/src/test/java/spark/template/rocker/RockerTransformerTest.java
+++ b/spark-template-rocker/src/test/java/spark/template/rocker/RockerTransformerTest.java
@@ -1,0 +1,16 @@
+package spark.template.rocker;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class RockerTransformerTest {
+
+    @Test
+    public void testRender() throws Exception {
+        String templateVariable = "Hello Rocker!";
+        String expected = String.format("<h1>%s</h1>\n", templateVariable);
+        String actual = new RockerTransformer().render(views.hello.template(templateVariable));
+	assertEquals(expected, actual);
+    }
+
+}

--- a/spark-template-rocker/src/test/java/spark/template/rocker/example/RockerEngineExample.java
+++ b/spark-template-rocker/src/test/java/spark/template/rocker/example/RockerEngineExample.java
@@ -1,0 +1,22 @@
+package spark.template.rocker.example;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import spark.ModelAndView;
+import spark.template.rocker.RockerEngine;
+import static spark.Spark.get;
+
+public class RockerEngineExample {
+
+    public static void main(String args[]) {
+
+        get("/hello", (request, response) -> {
+            Map<String, Object> model = new HashMap<>();
+            model.put("message", "Hello Rocker!");
+            return new ModelAndView(model, "views/hello.rocker.html");
+        }, new RockerEngine());
+
+    }
+
+}

--- a/spark-template-rocker/src/test/java/spark/template/rocker/example/RockerTransformerExample.java
+++ b/spark-template-rocker/src/test/java/spark/template/rocker/example/RockerTransformerExample.java
@@ -1,0 +1,16 @@
+package spark.template.rocker.example;
+
+import spark.template.rocker.RockerTransformer;
+import static spark.Spark.get;
+
+public class RockerTransformerExample {
+
+    public static void main(String args[]) {
+
+        get("/hello", (request, response) -> {
+	    return views.hello.template("Hello Rocker!");
+        }, new RockerTransformer());
+
+    }
+
+}

--- a/spark-template-rocker/src/test/java/views/hello.rocker.html
+++ b/spark-template-rocker/src/test/java/views/hello.rocker.html
@@ -1,0 +1,2 @@
+@args (String message)
+<h1>@message</h1>


### PR DESCRIPTION
Added a module for using [Rocker](https://github.com/fizzed/rocker) templates in Spark. 2 approaches using TemplateEngine and ResponseTransformer based on which way you like to invoke your Rocker templates.