### PR TITLE
Cleanup poms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-engines</artifactId>
     <packaging>pom</packaging>
-    <version>2.5.5</version>
+    <version>2.6-SNAPSHOT</version>
 
     <name>spark-template-engines</name>
     <description>Template Engine View Route implementations for Spark</description>

--- a/spark-template-closure/pom.xml
+++ b/spark-template-closure/pom.xml
@@ -25,23 +25,25 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.1</version>
-        </dependency>
         <dependency>
             <groupId>com.google.template</groupId>
             <artifactId>soy</artifactId>
             <version>2017-02-01</version>
         </dependency>
         <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-template-freemarker/pom.xml
+++ b/spark-template-freemarker/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-freemarker</artifactId>
     <packaging>jar</packaging>
-    <version>2.5.5</version>
+    <version>2.6-SNAPSHOT</version>
 
     <name>spark-template-freemarker</name>
     <description>Freemarker Template Engine implementation for Spark</description>
@@ -33,47 +33,25 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
-        <!-- LOGGING DEPENDENCIES -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.13</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.13</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.5</version>
-        </dependency>
-
         <dependency>
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
             <version>2.3.26-incubating</version>
         </dependency>
-
-        <!-- JUNIT DEPENDENCY FOR TESTING -->
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.1</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-template-handlebars/pom.xml
+++ b/spark-template-handlebars/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-handlebars</artifactId>
     <packaging>jar</packaging>
-    <version>2.5.5</version>
+    <version>2.6-SNAPSHOT</version>
 
     <name>spark-template-handlebars</name>
     <description>Handlebars Template Engine implementation for Spark</description>
@@ -25,14 +25,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.5</version>
-        </dependency>
         <dependency>
             <groupId>com.github.jknack</groupId>
             <artifactId>handlebars</artifactId>
@@ -44,9 +41,14 @@
             <version>4.0.6</version>
         </dependency>
         <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-template-jade/pom.xml
+++ b/spark-template-jade/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-jade</artifactId>
     <packaging>jar</packaging>
-    <version>2.5.5</version>
+    <version>2.6-SNAPSHOT</version>
 
     <name>spark-template-jade</name>
     <description>Jade Template Engine implementation for Spark</description>
@@ -25,23 +25,25 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.5</version>
-        </dependency>
         <dependency>
             <groupId>de.neuland-bfi</groupId>
             <artifactId>jade4j</artifactId>
             <version>1.2.5</version>
         </dependency>
         <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-template-jetbrick/pom.xml
+++ b/spark-template-jetbrick/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-jetbrick</artifactId>
     <packaging>jar</packaging>
-    <version>2.5.5</version>
+    <version>2.6-SNAPSHOT</version>
 
     <name>spark-template-jetbrick</name>
     <description>Jetbrick Template Engine implementation for Spark</description>
@@ -23,24 +23,28 @@
         </license>
     </licenses>
 
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
-        </dependency>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
+    </properties>
 
+    <dependencies>
         <dependency>
             <groupId>com.github.subchen</groupId>
             <artifactId>jetbrick-template</artifactId>
             <version>2.1.4</version>
         </dependency>
-
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>2.5.5</version>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/spark-template-jinjava/pom.xml
+++ b/spark-template-jinjava/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-jinjava</artifactId>
     <packaging>jar</packaging>
-    <version>2.5.5</version>
+    <version>2.6-SNAPSHOT</version>
 
     <name>spark-template-jinjava</name>
     <description>Jinjava Template Engine implementation for Spark</description>
@@ -25,25 +25,25 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.5</version>
-        </dependency>
-
         <dependency>
             <groupId>com.hubspot.jinjava</groupId>
             <artifactId>jinjava</artifactId>
             <version>2.1.19</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-template-jtwig/pom.xml
+++ b/spark-template-jtwig/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-jtwig</artifactId>
     <packaging>jar</packaging>
-    <version>2.5.5</version>
+    <version>2.6-SNAPSHOT</version>
 
     <name>spark-template-jtwig</name>
     <description>Jtwig Template Engine implementation for Spark</description>
@@ -25,6 +25,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <repositories>
@@ -36,19 +38,19 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.5</version>
-        </dependency>
-        <dependency>
             <groupId>org.jtwig</groupId>
             <artifactId>jtwig-core</artifactId>
             <version>5.85.3.RELEASE</version>
         </dependency>
         <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-template-mustache/pom.xml
+++ b/spark-template-mustache/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-mustache</artifactId>
     <packaging>jar</packaging>
-    <version>2.5.5</version>
+    <version>2.6-SNAPSHOT</version>
 
     <name>spark-template-mustache</name>
     <description>Mustache Template Engine implementation for Spark</description>
@@ -25,23 +25,25 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.5</version>
-        </dependency>
         <dependency>
             <groupId>com.github.spullara.mustache.java</groupId>
             <artifactId>compiler</artifactId>
             <version>0.9.4</version>
         </dependency>
         <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-template-pebble/pom.xml
+++ b/spark-template-pebble/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-pebble</artifactId>
     <packaging>jar</packaging>
-    <version>2.5.5</version>
+    <version>2.6-SNAPSHOT</version>
 
     <name>spark-template-pebble</name>
     <description>Pebble Template Engine implementation for Spark</description>
@@ -25,23 +25,25 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.5</version>
-        </dependency>
         <dependency>
             <groupId>com.mitchellbosecke</groupId>
             <artifactId>pebble</artifactId>
             <version>2.3.0</version>
         </dependency>
         <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-template-rocker/pom.xml
+++ b/spark-template-rocker/pom.xml
@@ -33,55 +33,31 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
-        <!-- LOGGING DEPENDENCIES -->
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.13</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.13</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.1</version>
-        </dependency>
-
-	<dependency>
             <groupId>com.fizzed</groupId>
             <artifactId>rocker-runtime</artifactId>
             <version>0.18.0</version>
         </dependency>
-
-        <!-- for hot-reloading support -->
         <dependency>
             <groupId>com.fizzed</groupId>
             <artifactId>rocker-compiler</artifactId>
             <version>0.18.0</version>
             <scope>provided</scope>
         </dependency>
-
-        <!-- JUNIT DEPENDENCY FOR TESTING -->
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.1</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-template-thymeleaf/pom.xml
+++ b/spark-template-thymeleaf/pom.xml
@@ -24,23 +24,25 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.5</version>
-        </dependency>
         <dependency>
             <groupId>org.thymeleaf</groupId>
             <artifactId>thymeleaf</artifactId>
             <version>3.0.5.RELEASE</version>
         </dependency>
         <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-template-velocity/pom.xml
+++ b/spark-template-velocity/pom.xml
@@ -9,7 +9,7 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-velocity</artifactId>
     <packaging>jar</packaging>
-    <version>2.5.5</version>
+    <version>2.6-SNAPSHOT</version>
 
     <name>spark-template-velocity</name>
     <description>Apache Velocity Template View Route implementation for Spark</description>
@@ -33,33 +33,25 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.5</version>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity</artifactId>
             <version>1.7</version>
         </dependency>
-
-        <!-- JUNIT DEPENDENCY FOR TESTING -->
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.3</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-template-water/pom.xml
+++ b/spark-template-water/pom.xml
@@ -12,21 +12,33 @@
     <groupId>com.sparkjava</groupId>
     <artifactId>spark-template-water</artifactId>
     <packaging>jar</packaging>
-    <version>2.3</version>
+    <version>2.6-SNAPSHOT</version>
 
     <name>spark-template-water</name>
     <url>http://www.sparkjava.com</url>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spark.version>2.5.5</spark.version>
+        <junit.version>4.12</junit.version>
+    </properties>
+
     <dependencies>
-        <dependency>
-            <groupId>com.sparkjava</groupId>
-            <artifactId>spark-core</artifactId>
-            <version>2.5.5</version>
-        </dependency>
         <dependency>
             <groupId>org.watertemplate</groupId>
             <artifactId>watertemplate-engine</artifactId>
             <version>1.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sparkjava</groupId>
+            <artifactId>spark-core</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Set dev version to 2.6-SNAPSHOT
- Set spark-versions to 2.5.5
- Set junit to 4.12
- Re-order dependencies
- Remove unused depedencies
- Remove empty newlines
- Format