### PR TITLE
Update default jTwig engine to 5.86.1

### DIFF
--- a/spark-template-jtwig/pom.xml
+++ b/spark-template-jtwig/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.jtwig</groupId>
             <artifactId>jtwig-core</artifactId>
-            <version>5.85.3.RELEASE</version>
+            <version>5.86.1.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>com.sparkjava</groupId>


### PR DESCRIPTION
As this one at least contains the ever critical `parent()` function, where the previous version used here (5.56.*) didn't