### PR TITLE
Set default caracter encoding UTF-8 to ThymeleafTemplateEngine

### DIFF
--- a/spark-template-thymeleaf/src/main/java/spark/template/thymeleaf/ThymeleafTemplateEngine.java
+++ b/spark-template-thymeleaf/src/main/java/spark/template/thymeleaf/ThymeleafTemplateEngine.java
@@ -40,6 +40,7 @@ public class ThymeleafTemplateEngine extends TemplateEngine {
     private static final String DEFAULT_PREFIX = "templates/";
     private static final String DEFAULT_SUFFIX = ".html";
     private static final long DEFAULT_CACHE_TTL_MS = 3600000L;
+    private static final long DEFAULT_CHARACTER_ENCODING = "UTF-8";
 
     private org.thymeleaf.TemplateEngine templateEngine;
 
@@ -84,6 +85,7 @@ public class ThymeleafTemplateEngine extends TemplateEngine {
         );
 
         templateResolver.setCacheTTLMs(DEFAULT_CACHE_TTL_MS);
+        templateResolver.setCharacterEncoding(DEFAULT_CHARACTER_ENCODING);
         return templateResolver;
     }
 


### PR DESCRIPTION
Hello! I'd like to specify default caracter encoding UTF-8, to prevent garbled characters in Japanese.

It occurs on Linux(CentOS 7), when locale is "LANG=C" then Thymeleaf uses [ANSI_X3.4-1968] encoding.
Actually, this setting is the default in SakuraVPS (Japanese VPS provider), so that need to avoid this.
I hope the sparkjava to be easier to use with default settings.