### PR TITLE
Update to Velocity 2.0, where context keys are always String.

### DIFF
--- a/spark-template-velocity/pom.xml
+++ b/spark-template-velocity/pom.xml
@@ -40,8 +40,8 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.velocity</groupId>
-            <artifactId>velocity</artifactId>
-            <version>1.7</version>
+            <artifactId>velocity-engine-core</artifactId>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>com.sparkjava</groupId>

--- a/spark-template-velocity/src/main/java/spark/template/velocity/VelocityTemplateEngine.java
+++ b/spark-template-velocity/src/main/java/spark/template/velocity/VelocityTemplateEngine.java
@@ -75,12 +75,13 @@ public class VelocityTemplateEngine extends TemplateEngine {
      * {@inheritDoc}
      */
     @Override
+    @SuppressWarnings("unchecked")
     public String render(ModelAndView modelAndView) {
         String templateEncoding = Optional.ofNullable(this.encoding).orElse(StandardCharsets.UTF_8.name());
         Template template = velocityEngine.getTemplate(modelAndView.getViewName(), templateEncoding);
         Object model = modelAndView.getModel();
         if (model instanceof Map) {
-            Map<?, ?> modelMap = (Map<?, ?>) model;
+            Map<String, Object> modelMap = (Map<String, Object>) model;
             VelocityContext context = new VelocityContext(modelMap);
             StringWriter writer = new StringWriter();
             template.merge(context, writer);


### PR DESCRIPTION
Fix for #68 . Velocity 2 enforces String as keys, so we end up with an unchecked cast that we have to suppress.