### PR TITLE
Make it easier to configure the Thymeleaf engine

### DIFF
--- a/spark-template-thymeleaf/src/main/java/spark/template/thymeleaf/ThymeleafTemplateEngine.java
+++ b/spark-template-thymeleaf/src/main/java/spark/template/thymeleaf/ThymeleafTemplateEngine.java
@@ -41,7 +41,7 @@ public class ThymeleafTemplateEngine extends TemplateEngine {
     private static final String DEFAULT_SUFFIX = ".html";
     private static final long DEFAULT_CACHE_TTL_MS = 3600000L;
 
-    private org.thymeleaf.TemplateEngine templateEngine;
+    protected org.thymeleaf.TemplateEngine templateEngine;
 
     /**
      * Constructs a default thymeleaf template engine.


### PR DESCRIPTION
Making the underlying `ThymeleafEngine` protected allows to subclass the `ThymeleafTemplateEngine` and access the `ThymeleafEngine` so it can be configured with additional features.